### PR TITLE
Fix broken test suite. Use consistent styling in ListRecipes command

### DIFF
--- a/app/Commands/ListRecipesCommand.php
+++ b/app/Commands/ListRecipesCommand.php
@@ -16,12 +16,12 @@ class ListRecipesCommand extends Command
         $this->newLine();
         $this->line('  <fg=white;options=bold>Mise</>  <fg=green;options=bold>' . config('app.version') . '</> ');
         $this->newLine();
-        $this->line('  <fg=yellow;options=bold>Recipes:</>');
+        $this->line('  <fg=yellow;options=bold>RECIPES</>');
         $this->line($this->recipes());
-        $this->line('  <fg=yellow;options=bold>Applying recipes:</>');
-        $this->line('    mise apply [recipes]');
+        $this->line('  <fg=yellow;options=bold>USAGE</>');
+        $this->line('    mise apply recipe [recipe ...]');
         $this->newLine();
-        $this->line('  <fg=yellow;options=bold>Examples:</>');
+        $this->line('  <fg=yellow;options=bold>EXAMPLES</>');
         $this->line('    mise apply tighten-basic-saas');
         $this->line('    mise apply tighten-basic-saas laravel-local-developer-tooling');
     }

--- a/app/Commands/ListRecipesCommand.php
+++ b/app/Commands/ListRecipesCommand.php
@@ -14,14 +14,14 @@ class ListRecipesCommand extends Command
     public function handle(): void
     {
         $this->newLine();
-        $this->line('Mise <info>' . config('app.version') . '</info> ');
+        $this->line('  <fg=white;options=bold>Mise</>  <fg=green;options=bold>' . config('app.version') . '</> ');
         $this->newLine();
-        $this->line('<fg=yellow>Recipes:</>');
+        $this->line('  <fg=yellow;options=bold>Recipes:</>');
         $this->line($this->recipes());
-        $this->line('<fg=yellow>Applying recipes:</>');
+        $this->line('  <fg=yellow;options=bold>Applying recipes:</>');
         $this->line('    mise apply [recipes]');
         $this->newLine();
-        $this->line('<fg=yellow>Examples:</>');
+        $this->line('  <fg=yellow;options=bold>Examples:</>');
         $this->line('    mise apply tighten-basic-saas');
         $this->line('    mise apply tighten-basic-saas laravel-local-developer-tooling');
     }
@@ -32,7 +32,7 @@ class ListRecipesCommand extends Command
         $padding = $recipes->keys()->max(fn ($recipe) => strlen($recipe) + 4);
 
         return $recipes->reduce(
-            fn ($carry, $recipeClass, $key) => sprintf("%s  <info>%s</info> %s\n", $carry, sprintf("%-{$padding}s", $key), app($recipeClass)->description())
+            fn ($carry, $recipeClass, $key) => sprintf("%s  <info>%s</info> %s\n", $carry, sprintf("  %-{$padding}s", $key), app($recipeClass)->description())
         );
     }
 }

--- a/app/Commands/ListRecipesCommand.php
+++ b/app/Commands/ListRecipesCommand.php
@@ -14,7 +14,7 @@ class ListRecipesCommand extends Command
     public function handle(): void
     {
         $this->newLine();
-        $this->line('Mise <info>v' . config('app.version') . '</info> ');
+        $this->line('Mise <info>' . config('app.version') . '</info> ');
         $this->newLine();
         $this->line('<fg=yellow>Recipes:</>');
         $this->line($this->recipes());

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,9 +11,6 @@
         <testsuite name="Feature">
             <directory>./tests/Feature</directory>
         </testsuite>
-        <testsuite name="Unit">
-            <directory>./tests/Unit</directory>
-        </testsuite>
     </testsuites>
     <source>
         <include>


### PR DESCRIPTION
- remove reference to unit test directory from `phpunit.xml.dist` causing pest to bail.
- update `App\Commands\ListRecipesCommand` to have conststent styling with Zero's default usage renderer.