### PR TITLE
Add VerifyEmailController stub for Breeze-like recipe

### DIFF
--- a/stubs/breeze/api-only/shared/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/stubs/breeze/api-only/shared/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\RedirectResponse;
+
+class VerifyEmailController extends Controller
+{
+    /**
+     * Mark the authenticated user's email address as verified.
+     */
+    public function __invoke(EmailVerificationRequest $request): RedirectResponse
+    {
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect()->intended(
+                config('app.frontend_url').'/dashboard?verified=1'
+            );
+        }
+
+        if ($request->user()->markEmailAsVerified()) {
+            event(new Verified($request->user()));
+        }
+
+        return redirect()->intended(
+            config('app.frontend_url').'/dashboard?verified=1'
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the missing `VerifyEmailController.php` stub to the controllers of the `laravel-breeze/api-only` recipe. This file is a copy of https://github.com/laravel/breeze/blob/2.x/stubs/api/app/Http/Controllers/Auth/VerifyEmailController.php.

With this stub copied, the Pest tests run successfully after applying the recipe in a new Laravel installation.