### PR TITLE
remove pointless autoload mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,7 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/",
-            "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/"
+            "App\\": "app/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
remove composer autoload mappings to `database/factories/` and `database/seeders/`.