### PR TITLE
Minimal exception handling

### DIFF
--- a/app/Tools/ConsoleCommand.php
+++ b/app/Tools/ConsoleCommand.php
@@ -2,13 +2,16 @@
 
 namespace Tighten\Mise\Tools;
 
+use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Support\Facades\Process;
 
 class ConsoleCommand
 {
+    private ProcessResult $result;
+
     public function exec(string $command): static
     {
-        Process::run($command);
+        $this->result = Process::run($command)->throw();
 
         return $this;
     }
@@ -18,5 +21,10 @@ class ConsoleCommand
         $this->exec("vendor/bin/{$command}");
 
         return $this;
+    }
+
+    public function result(): ProcessResult
+    {
+        return $this->result;
     }
 }


### PR DESCRIPTION
This closes #31. 

Currently, CLI Tools (those that extend `\Tighten\Mise\Tools\ConsoleCommand`) can fail but subsequent commands/steps will still execute. Ultimately, this means the recipe appears to complete successfully but the codebase is left in an unstable state.

This PR introduces the most basic exception handling to fix the issue.

**Exception Handling**
An `\Illuminate\Process\Exceptions\ProcessFailedException` is thrown if the underlying process fails. The underlying `\Illuminate\Process\ProcessResult` is available via the `result` attribute of the exception for interrogation.

Tools that extend from `\Tighten\Mise\Tools\ConsoleCommand` can:
- do nothing–the `\Illuminate\Process\Exceptions\ProcessFailedException` is thrown and halts excecution.
- wrap the exception in a try/catch and decide how best to proceed.

**Happy Path**
`\Tighten\Mise\Tools\ConsoleCommand` provides access to the underlying `\Illuminate\Process\ProcessResult` so that it can be interrogated in the happy-path.