### PR TITLE
Use format preserving pretty-printing

### DIFF
--- a/app/Tools/PhpParser.php
+++ b/app/Tools/PhpParser.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
@@ -28,6 +29,7 @@ class PhpParser
 
     /**
      * Central entry point for editing PHP files with PHP Parser.
+     * Uses formatting-preserving pretty printing to maintain original code style.
      *
      * @param  array<NodeVisitorAbstract>  $edits
      *
@@ -37,10 +39,24 @@ class PhpParser
     {
         Cache::put(self::ACTIVE_FILENAME_KEY, $phpFilePath);
 
-        $this->traverser($edits)
-            ->traverse($ast = $this->toAst($phpFilePath));
+        $code = Storage::get($phpFilePath);
 
-        Storage::put($phpFilePath, $this->toPhpFile($ast));
+        // Parse the code and save the tokens for format preservation
+        $oldStmts = $this->parser->parse($code);
+        $oldTokens = $this->parser->getTokens();
+
+        // Clone the AST before making changes
+        $cloningTraverser = new NodeTraverser;
+        $cloningTraverser->addVisitor(new NodeVisitor\CloningVisitor);
+        $newStmts = $cloningTraverser->traverse($oldStmts);
+
+        // Apply the edits to the cloned AST
+        $this->traverser($edits)->traverse($newStmts);
+
+        // Use format-preserving pretty printing
+        $newCode = $this->phpFilePrinter->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
+
+        Storage::put($phpFilePath, $newCode);
     }
 
     /**

--- a/app/Tools/PhpParser.php
+++ b/app/Tools/PhpParser.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
@@ -47,7 +47,7 @@ class PhpParser
 
         // Clone the AST before making changes
         $cloningTraverser = new NodeTraverser;
-        $cloningTraverser->addVisitor(new NodeVisitor\CloningVisitor);
+        $cloningTraverser->addVisitor(new CloningVisitor);
         $newStmts = $cloningTraverser->traverse($oldStmts);
 
         // Apply the edits to the cloned AST

--- a/tests/Feature/Tools/FileTest.php
+++ b/tests/Feature/Tools/FileTest.php
@@ -218,7 +218,7 @@ test('file->addImport(...) with other imports', function () {
 
     (new File)->addImports($path, 'App\Models\User');
 
-    expect(Storage::get($path))->toBe("<?php\n\nnamespace App\Awesome;\n\nuse App\Models\Contact;\nuse App\Models\User;\n\nclass Test\n{\n    // Some code\n}");
+    expect(Storage::get($path))->toBe("<?php\n\nnamespace App\Awesome;\n\nuse App\Models\Contact;\nuse App\Models\User;\n\nclass Test {\n    // Some code\n}");
 });
 
 test('file->addImport(...) skips duplicate imports', function () {


### PR DESCRIPTION
This pull request adds format preserving pretty-printing to the PhpParser class. This should preserve existing code formatting for AST nodes that remain unchanged.

You can read more about it here: https://github.com/nikic/PHP-Parser/blob/master/doc/component/Pretty_printing.markdown#formatting-preserving-pretty-printing